### PR TITLE
fixed hard-coded /bin/bash

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,4 @@
-#!/usr/env/bin bash
+#!/usr/bin/env bash
 
 current_dir=$1
 dest_lib="$current_dir/libraries.lua"

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/env/bin bash
 
 current_dir=$1
 dest_lib="$current_dir/libraries.lua"


### PR DESCRIPTION
Running on Nixos causes error because of hard-coded bash path, fix is to replace it with
`#!/usr/env/bin bash`
btw awesome project